### PR TITLE
removed last System.exit

### DIFF
--- a/src/main/java/nl/esciencecenter/xenon/examples/files/CopyFile.java
+++ b/src/main/java/nl/esciencecenter/xenon/examples/files/CopyFile.java
@@ -73,15 +73,13 @@ public class CopyFile {
         } catch (URISyntaxException | XenonException e) {
             System.out.println("CopyFile example failed: " + e.getMessage());
             e.printStackTrace();
-        } finally {
-			if (xenon != null) {
-				try {
-					// Finally, we end Xenon to release all resources
-					XenonFactory.endXenon(xenon);
-				} catch (XenonException ex) {
-					System.exit(1);
-				}
-			}
-		}
-    }
-}
+        }
+        
+        if (xenon != null) {
+        	// Finally, we end Xenon to release all resources
+			XenonFactory.endXenon(xenon);
+
+		} // if
+        
+    } // method main
+} // class CopyFile


### PR DESCRIPTION
System.exit at that point is superfluous and PMD/codacy doesnt like it. Also the try catch block is not needed (I think): if xenon not is null, then you should be able to end it.